### PR TITLE
Remove uglify-js from require

### DIFF
--- a/lib/node-coveraje.js
+++ b/lib/node-coveraje.js
@@ -9,8 +9,7 @@
 var coveraje = (function () {
     "use strict";
     
-    var uglifyjs = require("uglify-js"),
-        CoverajeEvent = require("./EventEmitter"),
+    var CoverajeEvent = require("./EventEmitter"),
         Coveraje = require("./core"),
         coverajeWebserver = require("./webserver"),
         utils = require("./utils"),


### PR DESCRIPTION
Currently fails if one installs latest from npm since it tries to require `uglify-js` and it's not listed as a dependency.
