### PR TITLE
Fixes Gh 22

### DIFF
--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -1,47 +1,47 @@
 /*
     coveraje - a simple javascript code coverage tool.
-    
+
     TestRunner
-    
+
     Copyright (c) 2011-2012 Wolfgang Kluge (klugesoftware.de, gehirnwindung.de)
 */
 
 (function () {
     "use strict";
-    
+
     var vm = require("vm"),
         CoverajeTimer = require("./TimerProxy"),
         CoverajeEvent = require("./EventEmitter"),
         isOwn = require("./utils").isOwn;
-    
+
     function TestRunner(instance) {
         var option = instance.options;
         var shell = require("./shell").createShell(option);
-        
+
         function setNewTimer(ctx) {
             var timer = new CoverajeTimer();
-            
+
             ctx.setTimeout = timer.setTimeout;
             ctx.clearTimeout = timer.clearTimeout;
             ctx.setInterval = timer.clearTimeout;
             ctx.clearInterval = timer.clearTimeout;
             ctx[option.prefix + "stopTimers"] = timer.stopTimers;
         }
-        
+
         function createContext() {
             /*jshint browser: true*/
             var context = vm.createContext();
-            
+
             context[option.prefix + "runtime"] = instance.runtime;
             context.console = console;
-            
+
             setNewTimer(context);
-            
+
             var ctxs = option.globals.split(/\s+/g);
             var ctxl = ctxs.length;
             for (var i = 0; i < ctxl; i++) {
                 var bshared = false;
-                
+
                 if (ctxs[i] === "browser") {
                     if (context.window == null) {
                         try {
@@ -72,7 +72,7 @@
                     }
                 } else if (ctxs[i] === "node") {
                     var Module = require("module");
-                    
+
                     if (context.global == null) context.global = global;
                     if (context.process == null) context.process = process;
                     if (context.require == null) context.require = require;
@@ -90,10 +90,10 @@
             }
             return context;
         }
-        
+
         function run(runner, key, context, event) {
             var ctx = context;
-            
+
             function postRun() {
                 // stop all timers now
                 process.nextTick(function () {
@@ -101,13 +101,13 @@
                     event.complete(key, ctx);
                 });
             }
-            
+
             setNewTimer(ctx); // each run has its own timer
-            
+
             var testEvent;
-            
+
             shell.writeLine("run <color bright white>%s</color>", key || "");
-            
+
             try {
                 testEvent = runner(ctx, instance);
             } catch (ex) {
@@ -115,7 +115,7 @@
                 postRun();
                 return;
             }
-            
+
             if (testEvent instanceof CoverajeEvent) {
                 testEvent
                     .onComplete(postRun)
@@ -129,17 +129,17 @@
                 ctx.setTimeout(postRun, option.wait);
             }
         }
-        
+
         function runMultiple(runner, context, event) {
             var runKeys = [], rk, rkl;
             var completed = [], errors = [];
-            
+
             for (rk in runner) {
                 if (isOwn(runner, rk) && typeof runner[rk] === "function") {
                     runKeys.push(rk);
                 }
             }
-            
+
             rkl = runKeys.length;
             if (rkl === 0) {
                 event.complete("", context);
@@ -148,17 +148,17 @@
                 run(runner[rk], rk, context, event);
             } else {
                 var me = new CoverajeEvent();
-                
+
                 me
                     .onComplete(function (key) {
                         if (completed.indexOf(key) === -1) {
                             shell.write(".");
                             completed.push(key);
                         }
-                        
+
                         if (runKeys.length === completed.length) {
                             shell.writeLine(" complete");
-                            
+
                             for (var i = 0; i < errors.length; i++) {
                                 event.error(errors[i].k, errors[i].m);
                             }
@@ -168,22 +168,22 @@
                     .onError(function (key, msg) {
                         errors.push({k: key, m: msg});
                     });
-                
+
                 for (var i = 0; i < runKeys.length; i++) {
                     rk = runKeys[i];
                     run(runner[rk], rk, context, me);
                 }
             }
-            
+
         }
-        
+
         //
         // run the injected code and one or all test runners
         // in their own context
         function runTest(code, runner) {
             /*jshint browser: true*/
             var event = new CoverajeEvent();
-            
+
             event
                 .onComplete(function () {
                     instance.complete(instance);
@@ -193,7 +193,7 @@
                 })
                 .onStart(function (key) {
                     instance.runtime.reset();
-                    
+
                     var context = createContext();
                     try {
                         var script = vm.createScript(code.codeToRun, "initial code");
@@ -202,7 +202,7 @@
                         event.error(key, ex2.stack ? ex2.stack : ex2);
                         return;
                     }
-                    
+
                     if (key != null && key !== "") {
                         runner = runner[key];
                         if (typeof runner !== "function") {
@@ -210,7 +210,7 @@
                             return;
                         }
                     }
-                    
+
                     if (runner == null) {
                         // set to complete, even if no runners are defined
                         event.complete();
@@ -228,15 +228,15 @@
                         }
                     }
                 });
-            
+
             return event;
         }
-        
+
         return {
             runTest: runTest
         };
     }
-    
+
     if (typeof module !== "undefined") {
         module.exports = TestRunner;
     }

--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -76,7 +76,6 @@
                     if (context.global == null) context.global = global;
                     if (context.process == null) context.process = process;
                     if (context.require == null) context.require = require;
-                    if (context.exports == null) context.exports = {};
                     if (context.__filename == null) context.__filename = process.mainModule.filename;
                     if (context.__dirname == null) context.__dirname = require("path").dirname(context.__filename);
                     if (context.module == null) {
@@ -85,7 +84,11 @@
                             context.module = new Module(context.__filename + "$$cj", module);
                             context.module.filename = context.__filename;
                         }
+                        if (context.module.exports == null) {
+                            context.module.exports = {};
+                        }
                     }
+                    if (context.exports == null) context.exports = context.module.exports;
                 }
             }
             return context;


### PR DESCRIPTION
My use case is that I'm using the instrumented function returned by coverage. But sometimes a user may do

```
module.exports = function () { };
```

Other times

```
exports.foo = function foo() { };
```

If I return `context.module.exports` with the current code, the first example works but not the second.

Basically, module.exports should be exports.
